### PR TITLE
Fix adaptive/non unity build error

### DIFF
--- a/Plugins/Linter/Source/Linter/Private/LintRuleSet.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRuleSet.cpp
@@ -1,5 +1,7 @@
 #include "LintRuleSet.h"
 #include "LintRunner.h"
+#include "AnyObject_LinterDummyClass.h"
+#include "LinterNamingConvention.h"
 
 #include "AssetRegistryModule.h"
 #include "Modules/ModuleManager.h"

--- a/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_ConfigCategories.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Blueprint_Vars_ConfigCategories.cpp
@@ -3,6 +3,7 @@
 #include "LintRuleSet.h"
 #include "Engine/Blueprint.h"
 #include "EdGraphSchema_K2.h"
+#include "Kismet2/BlueprintEditorUtils.h"
 
 ULintRule_Blueprint_Vars_ConfigCategories::ULintRule_Blueprint_Vars_ConfigCategories(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_IsNamedCorrectly_Base.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_IsNamedCorrectly_Base.cpp
@@ -2,6 +2,7 @@
 #include "LintRules/LintRule_IsNamedCorrectly_Base.h"
 #include "LintRuleSet.h"
 #include "LinterNamingConvention.h"
+#include "Engine/Blueprint.h"
 
 ULintRule_IsNamedCorrectly_Base::ULintRule_IsNamedCorrectly_Base(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_StaticMesh_ValidUVs.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_StaticMesh_ValidUVs.cpp
@@ -3,6 +3,7 @@
 #include "LintRuleSet.h"
 #include "LinterNamingConvention.h"
 #include "HAL/FileManager.h"
+#include "Engine/StaticMesh.h"
 
 ULintRule_StaticMesh_ValidUVs::ULintRule_StaticMesh_ValidUVs(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Texture_Size_NotTooBig.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Texture_Size_NotTooBig.cpp
@@ -3,6 +3,7 @@
 #include "LintRuleSet.h"
 #include "LinterNamingConvention.h"
 #include "HAL/FileManager.h"
+#include "Engine/Texture2D.h"
 
 ULintRule_Texture_Size_NotTooBig::ULintRule_Texture_Size_NotTooBig(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Texture_Size_PowerOfTwo.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRules/LintRule_Texture_Size_PowerOfTwo.cpp
@@ -3,6 +3,7 @@
 #include "LintRuleSet.h"
 #include "LinterNamingConvention.h"
 #include "HAL/FileManager.h"
+#include "Engine/Texture2D.h"
 
 ULintRule_Texture_Size_PowerOfTwo::ULintRule_Texture_Size_PowerOfTwo(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Plugins/Linter/Source/Linter/Private/LintRunner.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LintRunner.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2018 Epic Games, Inc. All Rights Reserved.
 #include "LintRunner.h"
+#include "LintRuleSet.h"
 
 #define LOCTEXT_NAMESPACE "Linter"
 

--- a/Plugins/Linter/Source/Linter/Private/LinterCommandlet.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LinterCommandlet.cpp
@@ -14,6 +14,8 @@
 #include "Serialization/JsonSerializer.h"
 #include "Linter.h"
 #include "LintRule.h"
+#include "LintRuleSet.h"
+#include "LinterSettings.h"
 
 DEFINE_LOG_CATEGORY_STATIC(LinterCommandlet, All, All);
 

--- a/Plugins/Linter/Source/Linter/Private/LinterContentBrowserExtensions.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LinterContentBrowserExtensions.cpp
@@ -12,6 +12,8 @@
 #include "Framework/Commands/UIAction.h"
 #include "Delegates/IDelegateInstance.h"
 #include "TooltipEditor/TooltipTool.h"
+#include "Linter.h"
+#include "BatchRenameTool/BatchRenameTool.h"
 
 #define LOCTEXT_NAMESPACE "Linter"
 DEFINE_LOG_CATEGORY_STATIC(LinterContentBrowserExtensions, Log, All);

--- a/Plugins/Linter/Source/Linter/Private/LinterNamingConvention.cpp
+++ b/Plugins/Linter/Source/Linter/Private/LinterNamingConvention.cpp
@@ -4,6 +4,7 @@
 #include "Templates/SharedPointer.h"
 #include "DetailCategoryBuilder.h"
 #include "IDetailChildrenBuilder.h"
+#include "AnyObject_LinterDummyClass.h"
 
 TSharedRef<IDetailCustomization> FLinterNamingConventionDetails::MakeInstance()
 {

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReport.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReport.cpp
@@ -24,6 +24,15 @@
 #include "Misc/FileHelper.h"
 #include "Widgets/Input/SComboButton.h"
 #include "UI/LintReportRuleDetails.h"
+#include "LinterStyle.h"
+#include "Linter.h"
+#include "Interfaces/IPluginManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Widgets/Input/SButton.h"
+#include "EditorStyleSet.h"
+#include "Widgets/Images/SImage.h"
+#include "Framework/MultiBox/MultiBoxExtender.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 
 #define LOCTEXT_NAMESPACE "Linter"
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetDetails.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetDetails.cpp
@@ -19,6 +19,8 @@
 #include "UI/LintReportAssetError.h"
 #include "LintRule.h"
 #include "AssetThumbnail.h"
+#include "UI/LintReportAssetErrorList.h"
+#include "Widgets/Layout/SBox.h"
 
 
 #define LOCTEXT_NAMESPACE "LintReport"

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetError.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetError.cpp
@@ -8,6 +8,8 @@
 #include "Widgets/Views/SListView.h"
 #include "Widgets/Views/STableRow.h"
 #include "Widgets/Layout/SBox.h"
+#include "Widgets/Images/SImage.h"
+#include "LinterStyle.h"
 
 #define LOCTEXT_NAMESPACE "LintReport"
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetErrorList.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportAssetErrorList.cpp
@@ -18,6 +18,7 @@
 #include "Framework/Views/ITypedTableView.h"
 #include "UI/LintReportAssetError.h"
 #include "LintRule.h"
+#include "Widgets/Views/SListView.h"
 
 #define LOCTEXT_NAMESPACE "LintReport"
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleDetails.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleDetails.cpp
@@ -19,6 +19,8 @@
 #include "UI/LintReportRuleErrorList.h"
 #include "LintRule.h"
 #include "AssetThumbnail.h"
+#include "Widgets/Layout/SBox.h"
+#include "Widgets/Images/SImage.h"
 
 
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleError.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleError.cpp
@@ -8,6 +8,10 @@
 #include "Widgets/Views/SListView.h"
 #include "Widgets/Views/STableRow.h"
 #include "Widgets/Layout/SBox.h"
+#include "LinterStyle.h"
+#include "ContentBrowserModule.h"
+#include "AssetRegistryModule.h"
+#include "IContentBrowserSingleton.h"
 
 #define LOCTEXT_NAMESPACE "LintReport"
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleErrorList.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintReportRuleErrorList.cpp
@@ -18,7 +18,10 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Framework/Views/ITypedTableView.h"
 #include "UI/LintReportAssetError.h"
+#include "UI/LintReportAssetErrorList.h"
+#include "UI/LintReportRuleError.h"
 #include "LintRule.h"
+#include "Widgets/Views/SListView.h"
 
 #define LOCTEXT_NAMESPACE "LintReport"
 

--- a/Plugins/Linter/Source/Linter/Private/UI/LintWizard.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/LintWizard.cpp
@@ -19,6 +19,14 @@
 #include "FileHelpers.h"
 #include "Logging/MessageLog.h"
 #include "Logging/TokenizedMessage.h"
+#include "ContentBrowserModule.h"
+#include "DesktopPlatformModule.h"
+#include "AssetToolsModule.h"
+#include "Framework/Docking/TabManager.h"
+#include "Widgets/Input/SComboBox.h"
+#include "Widgets/Docking/SDockTab.h"
+#include "Misc/App.h"
+#include "Engine/World.h"
 
 #include "LinterStyle.h"
 #include "LintRuleSet.h"
@@ -26,6 +34,7 @@
 #include "UI/SAssetLinkWidget.h"
 
 
+#define LOCTEXT_NAMESPACE "LinterWizard"
 
 BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
 void SLintWizard::Construct(const FArguments& InArgs)
@@ -650,3 +659,5 @@ bool SLintWizard::LoadAssetsIfNeeded(const TArray<FString>& ObjectPaths, TArray<
 
 	return true;
 }
+
+#undef LOCTEXT_NAMESPACE

--- a/Plugins/Linter/Source/Linter/Private/UI/SAssetLinkWidget.cpp
+++ b/Plugins/Linter/Source/Linter/Private/UI/SAssetLinkWidget.cpp
@@ -8,6 +8,11 @@
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Images/SThrobber.h"
 #include "Widgets/Text/SRichTextBlock.h"
+#include "Widgets/Input/SHyperlink.h"
+#include "SlateOptMacros.h"
+#include "ContentBrowserModule.h"
+#include "AssetRegistryModule.h"
+#include "IContentBrowserSingleton.h"
 
 BEGIN_SLATE_FUNCTION_BUILD_OPTIMIZATION
 void SAssetLinkWidget::Construct(const FArguments& Args)

--- a/Plugins/Linter/Source/Linter/Public/BatchRenameTool/BatchRenameTool.h
+++ b/Plugins/Linter/Source/Linter/Public/BatchRenameTool/BatchRenameTool.h
@@ -10,6 +10,7 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Layout/SUniformGridPanel.h"
 #include "Widgets/Layout/SSeparator.h"
+#include "AssetData.h"
 
 #define LOCTEXT_NAMESPACE "LinterBatchRenamer"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRule.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRule.h
@@ -2,7 +2,11 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "AssetData.h"
+#include "Templates/SubclassOf.h"
 #include "LintRule.generated.h"
+
+class ULintRule;
 
 UENUM(BlueprintType)
 enum class ELintRuleSeverity : uint8

--- a/Plugins/Linter/Source/Linter/Public/LintRuleSet.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRuleSet.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "Misc/ScopedSlowTask.h"
+#include "Engine/DataAsset.h"
 #include "LintRule.h"
 
 #include "LintRuleSet.generated.h"

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Compiles.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Compiles.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Compiles.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_MaxNodes.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_MaxNodes.h
@@ -3,8 +3,11 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Funcs_MaxNodes.generated.h"
+
+class UEdGraphNode;
 
 UCLASS(BlueprintType, Blueprintable, Abstract)
 class LINTER_API ULintRule_Blueprint_Funcs_MaxNodes : public ULintRule_Blueprint_Base

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_MustHaveReturn.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_MustHaveReturn.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Funcs_MustHaveReturn.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_PublicDescriptions.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Funcs_PublicDescriptions.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Funcs_PublicDescriptions.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_LooseNodes.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_LooseNodes.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_LooseNodes.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_ConfigCategories.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_ConfigCategories.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_ConfigCategories.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_EditableMustHaveTooltip.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_EditableMustHaveTooltip.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_EditableMustHaveTooltip.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_NoConfigFlag.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_NoConfigFlag.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_NoConfigFlag.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_NonAtomic.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_NonAtomic.h
@@ -3,8 +3,11 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_NonAtomic.generated.h"
+
+struct FBPVariableDescription;
 
 UCLASS(BlueprintType, Blueprintable, Abstract)
 class LINTER_API ULintRule_Blueprint_Vars_NonAtomic : public ULintRule_Blueprint_Base

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_PluralArrays.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_PluralArrays.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_PluralArrays.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_Regex.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRules/LintRule_Blueprint_Vars_Regex.h
@@ -3,6 +3,7 @@
 
 #include "CoreMinimal.h"
 #include "LintRule.h"
+#include "LintRule_Blueprint_Base.h"
 
 #include "LintRule_Blueprint_Vars_Regex.generated.h"
 

--- a/Plugins/Linter/Source/Linter/Public/LintRunner.h
+++ b/Plugins/Linter/Source/Linter/Public/LintRunner.h
@@ -7,6 +7,10 @@
 #include "AssetData.h"
 #include "Linter.h"
 
+class ULintRuleSet;
+struct FLintRuleList;
+struct FLintRuleViolation;
+
 class FLintRunner : public FRunnable
 {
 

--- a/Plugins/Linter/Source/Linter/Public/LinterContentBrowserExtensions.h
+++ b/Plugins/Linter/Source/Linter/Public/LinterContentBrowserExtensions.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+class FLinterModule;
 
 // Integrate Linter actions into the Content Browser
 class FLinterContentBrowserExtensions

--- a/Plugins/Linter/Source/Linter/Public/LinterNamingConvention.h
+++ b/Plugins/Linter/Source/Linter/Public/LinterNamingConvention.h
@@ -6,6 +6,7 @@
 #include "Templates/SharedPointer.h"
 #include "IDetailCustomization.h"
 #include "PropertyHandle.h"
+#include "Engine/DataAsset.h"
 #include "LinterNamingConvention.generated.h"
 
 

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReport.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReport.h
@@ -7,6 +7,10 @@
 #include "LintReportAssetError.h"
 #include "LintRule.h"
 
+class STextBlock;
+class SComboButton;
+class SScrollBox;
+struct FLintRuleViolation;
 
 class SLintReport : public SCompoundWidget
 {

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetDetails.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetDetails.h
@@ -1,7 +1,11 @@
 // Copyright 2019-2020 Gamemakin LLC. All Rights Reserved.
 #pragma once
 #include "Widgets/SCompoundWidget.h"
-#include "LintRule.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "AssetData.h"
+
+struct FLintRuleViolation;
+class FAssetThumbnailPool;
 
 class SLintReportAssetDetails : public SCompoundWidget
 {

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetError.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetError.h
@@ -1,6 +1,7 @@
 // Copyright 2019-2020 Gamemakin LLC. All Rights Reserved.
 #pragma once
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
 #include "LintRule.h"
 
 class SLintReportAssetError : public SCompoundWidget

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetErrorList.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportAssetErrorList.h
@@ -3,6 +3,8 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
 
+struct FLintRuleViolation;
+
 class SLintReportAssetErrorList : public SCompoundWidget
 {
 public:

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleDetails.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleDetails.h
@@ -1,7 +1,12 @@
 // Copyright 2019-2020 Gamemakin LLC. All Rights Reserved.
 #pragma once
 #include "Widgets/SCompoundWidget.h"
-#include "LintRule.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+#include "AssetData.h"
+
+struct FLintRuleViolation;
+class FAssetThumbnailPool;
+class SBox;
 
 class SLintReportRuleDetails : public SCompoundWidget
 {

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleError.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleError.h
@@ -1,7 +1,9 @@
 // Copyright 2019-2020 Gamemakin LLC. All Rights Reserved.
 #pragma once
 #include "Widgets/SCompoundWidget.h"
-#include "LintRule.h"
+#include "Widgets/DeclarativeSyntaxSupport.h"
+
+struct FLintRuleViolation;
 
 class SLintReportRuleError : public SCompoundWidget
 {

--- a/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleErrorList.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintReportRuleErrorList.h
@@ -3,6 +3,8 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/DeclarativeSyntaxSupport.h"
 
+struct FLintRuleViolation;
+
 class SLintReportRuleErrorList : public SCompoundWidget
 {
 public:

--- a/Plugins/Linter/Source/Linter/Public/UI/LintWizard.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/LintWizard.h
@@ -9,6 +9,9 @@
 
 #include "LintReport.h"
 
+template <typename OptionType>
+class SComboBox;
+
 /**
  * 
  */

--- a/Plugins/Linter/Source/Linter/Public/UI/SAssetLinkWidget.h
+++ b/Plugins/Linter/Source/Linter/Public/UI/SAssetLinkWidget.h
@@ -7,6 +7,7 @@
 #include "Widgets/SCompoundWidget.h"
 #include "Types/SlateStructs.h"
 #include "Misc/ScopedSlowTask.h"
+#include "AssetData.h"
 
 class SAssetLinkWidget : public SCompoundWidget
 {


### PR DESCRIPTION
 - include header
 - forward declaration

for testing non unity build : UnrealBuildTool.ModuleRules.bUseUnity = false;

(cherry picked from commit 58dbaff0e89f904c1924775854bbc8ddfda32fc2)